### PR TITLE
追加：動く壁(バグあり)

### DIFF
--- a/Assets/Prefab.meta
+++ b/Assets/Prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd5f496b276c6c64bbc18e807900bfd4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefab/Wall.prefab
+++ b/Assets/Prefab/Wall.prefab
@@ -15,7 +15,7 @@ GameObject:
   - component: {fileID: 210825253085688665}
   m_Layer: 0
   m_Name: Wall
-  m_TagString: Untagged
+  m_TagString: Wall
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0

--- a/Assets/Prefab/Wall.prefab
+++ b/Assets/Prefab/Wall.prefab
@@ -110,7 +110,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 386ec9c8df386644b910d86f957b9c2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  wallMoveTime: 5
+  moveWallSeconds: 5
 --- !u!61 &210825253085688665
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Prefab/Wall.prefab
+++ b/Assets/Prefab/Wall.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 2912719507659945997}
   - component: {fileID: -4257858612960175279}
   - component: {fileID: 2562579521514770593}
+  - component: {fileID: 210825253085688665}
   m_Layer: 0
   m_Name: Wall
   m_TagString: Untagged
@@ -109,4 +110,30 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 386ec9c8df386644b910d86f957b9c2e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  MoveTime: 5
+  wallMoveTime: 5
+--- !u!61 &210825253085688665
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2912719507659945987}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 1, y: 1}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1}
+  m_EdgeRadius: 0

--- a/Assets/Prefab/Wall.prefab
+++ b/Assets/Prefab/Wall.prefab
@@ -1,0 +1,112 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2912719507659945987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2912719507659945996}
+  - component: {fileID: 2912719507659945997}
+  - component: {fileID: -4257858612960175279}
+  - component: {fileID: 2562579521514770593}
+  m_Layer: 0
+  m_Name: Wall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2912719507659945996
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2912719507659945987}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 11, y: 6, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &2912719507659945997
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2912719507659945987}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
+  m_Color: {r: 1, g: 0.7311321, b: 0.7311321, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!114 &-4257858612960175279
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2912719507659945987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0b87cb62f622a9d43ac3c796ea507281, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  wallAnimation: {fileID: 2562579521514770593}
+--- !u!114 &2562579521514770593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2912719507659945987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 386ec9c8df386644b910d86f957b9c2e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  MoveTime: 5

--- a/Assets/Prefab/Wall.prefab.meta
+++ b/Assets/Prefab/Wall.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c88c86f5d35c31947b144853ada54537
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/DOTweenSettings.asset
+++ b/Assets/Resources/DOTweenSettings.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   showUnityEditorReport: 0
   logBehaviour: 0
   drawGizmos: 1
-  defaultRecyclable: 0
+  defaultRecyclable: 1
   defaultAutoPlay: 3
   defaultUpdateType: 0
   defaultTimeScaleIndependent: 0

--- a/Assets/Scenes/Noguchi.unity
+++ b/Assets/Scenes/Noguchi.unity
@@ -138,7 +138,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &130803431
 Transform:
   m_ObjectHideFlags: 0
@@ -596,7 +596,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1713400671
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Noguchi.unity
+++ b/Assets/Scenes/Noguchi.unity
@@ -173,7 +173,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &444944731
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -352,6 +352,7 @@ Transform:
   - {fileID: 130803431}
   - {fileID: 1713400671}
   - {fileID: 1774561609}
+  - {fileID: 1224093479}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -367,7 +368,7 @@ GameObject:
   - component: {fileID: 767136768}
   - component: {fileID: 767136767}
   m_Layer: 5
-  m_Name: DosplayGoText
+  m_Name: DisplayGo
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -419,13 +420,13 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 130
-    m_Alignment: 0
+    m_Alignment: 1
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: Go!
+  m_Text: 
 --- !u!222 &767136768
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -446,7 +447,7 @@ GameObject:
   - component: {fileID: 831529207}
   - component: {fileID: 831529206}
   m_Layer: 5
-  m_Name: CloseWallTimerText
+  m_Name: CloseWallTimer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -498,13 +499,13 @@ MonoBehaviour:
     m_BestFit: 0
     m_MinSize: 0
     m_MaxSize: 300
-    m_Alignment: 0
+    m_Alignment: 1
     m_AlignByGeometry: 0
     m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
+    m_HorizontalOverflow: 1
+    m_VerticalOverflow: 1
     m_LineSpacing: 1
-  m_Text: 3
+  m_Text: 
 --- !u!222 &831529207
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -534,7 +535,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!114 &975971187
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -547,6 +548,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 7ec72fef5a5dd8b4eb71de4d03cdeef7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  closeWallTimerText: {fileID: 831529206}
+  displayGoText: {fileID: 767136767}
+  countStartTime: 3
 --- !u!4 &975971188
 Transform:
   m_ObjectHideFlags: 0
@@ -697,6 +701,38 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
   m_PrefabInstance: {fileID: 1050175183}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1224093478
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1224093479}
+  m_Layer: 0
+  m_Name: 'testWall '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1224093479
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1224093478}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1751291775}
+  - {fileID: 1663756478}
+  m_Father: {fileID: 763872998}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1357014367
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -770,6 +806,11 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
   m_PrefabInstance: {fileID: 1357014367}
+  m_PrefabAsset: {fileID: 0}
+--- !u!4 &1663756478 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 1908167975}
   m_PrefabAsset: {fileID: 0}
 --- !u!1 &1681359497
 GameObject:
@@ -964,7 +1005,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1713400671
 Transform:
   m_ObjectHideFlags: 0
@@ -981,6 +1022,68 @@ Transform:
   m_Father: {fileID: 763872998}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1001 &1725569183
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1224093479}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+--- !u!4 &1751291775 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 1725569183}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1774561608
 GameObject:
   m_ObjectHideFlags: 0
@@ -1063,6 +1166,75 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &1908167975
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1224093479}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.b
+      value: 0.9312727
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.r
+      value: 0.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}
 --- !u!1001 &2912719508535047108
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Noguchi.unity
+++ b/Assets/Scenes/Noguchi.unity
@@ -138,7 +138,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &130803431
 Transform:
   m_ObjectHideFlags: 0
@@ -154,6 +154,173 @@ Transform:
   - {fileID: 1050175184}
   m_Father: {fileID: 763872998}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &444944730
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 444944734}
+  - component: {fileID: 444944733}
+  - component: {fileID: 444944732}
+  - component: {fileID: 444944731}
+  m_Layer: 5
+  m_Name: Canvas
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &444944731
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444944730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreReversedGraphics: 1
+  m_BlockingObjects: 0
+  m_BlockingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+--- !u!114 &444944732
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444944730}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_UiScaleMode: 0
+  m_ReferencePixelsPerUnit: 100
+  m_ScaleFactor: 1
+  m_ReferenceResolution: {x: 800, y: 600}
+  m_ScreenMatchMode: 0
+  m_MatchWidthOrHeight: 0
+  m_PhysicalUnit: 3
+  m_FallbackScreenDPI: 96
+  m_DefaultSpriteDPI: 96
+  m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
+--- !u!223 &444944733
+Canvas:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444944730}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_RenderMode: 1
+  m_Camera: {fileID: 1681359499}
+  m_PlaneDistance: 5
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_OverridePixelPerfect: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+  m_TargetDisplay: 0
+--- !u!224 &444944734
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 444944730}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 831529205}
+  - {fileID: 767136766}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0, y: 0}
+--- !u!1 &481455344
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 481455347}
+  - component: {fileID: 481455346}
+  - component: {fileID: 481455345}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &481455345
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481455344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &481455346
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481455344}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &481455347
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 481455344}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &763872997
 GameObject:
@@ -188,11 +355,212 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &767136765
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 767136766}
+  - component: {fileID: 767136768}
+  - component: {fileID: 767136767}
+  m_Layer: 5
+  m_Name: DosplayGoText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &767136766
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 767136765}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 444944734}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 200}
+  m_SizeDelta: {x: 230, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &767136767
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 767136765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 130
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 130
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Go!
+--- !u!222 &767136768
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 767136765}
+  m_CullTransparentMesh: 1
+--- !u!1 &831529204
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 831529205}
+  - component: {fileID: 831529207}
+  - component: {fileID: 831529206}
+  m_Layer: 5
+  m_Name: CloseWallTimerText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &831529205
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831529204}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 444944734}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 200}
+  m_SizeDelta: {x: 150, y: 150}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &831529206
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831529204}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 130
+    m_FontStyle: 1
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 300
+    m_Alignment: 0
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 3
+--- !u!222 &831529207
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 831529204}
+  m_CullTransparentMesh: 1
 --- !u!4 &889129928 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
   m_PrefabInstance: {fileID: 2912719508535047108}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &975971186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975971188}
+  - component: {fileID: 975971187}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &975971187
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975971186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7ec72fef5a5dd8b4eb71de4d03cdeef7, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &975971188
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 975971186}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -5}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1010405424
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -596,7 +964,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &1713400671
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Noguchi.unity
+++ b/Assets/Scenes/Noguchi.unity
@@ -138,7 +138,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &130803431
 Transform:
   m_ObjectHideFlags: 0
@@ -151,92 +151,10 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 889129928}
-  - {fileID: 277324576}
+  - {fileID: 1050175184}
   m_Father: {fileID: 763872998}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &277324575
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 277324576}
-  - component: {fileID: 277324577}
-  m_Layer: 0
-  m_Name: Wall (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &277324576
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 277324575}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: -3, z: 0}
-  m_LocalScale: {x: 11, y: 6, z: 1}
-  m_Children: []
-  m_Father: {fileID: 130803431}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &277324577
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 277324575}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 0.16509432, g: 1, b: 0.65306807, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &763872997
 GameObject:
   m_ObjectHideFlags: 0
@@ -265,257 +183,226 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 130803431}
-  - {fileID: 1843739291}
+  - {fileID: 1713400671}
   - {fileID: 1774561609}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &861258843
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 861258844}
-  - component: {fileID: 861258845}
-  m_Layer: 0
-  m_Name: Wall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &861258844
+--- !u!4 &889129928 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 2912719508535047108}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 861258843}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: 3, y: 0, z: 0}
-  m_LocalScale: {x: 11, y: 6, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1843739291}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!212 &861258845
-SpriteRenderer:
+--- !u!1001 &1010405424
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 861258843}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 1, g: 0.7311321, b: 0.7311321, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &889129927
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 889129928}
-  - component: {fileID: 889129929}
-  m_Layer: 0
-  m_Name: Wall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &889129928
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1713400671}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+--- !u!4 &1010405425 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 1010405424}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889129927}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 3, z: 0}
-  m_LocalScale: {x: 11, y: 6, z: 1}
-  m_Children: []
-  m_Father: {fileID: 130803431}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &889129929
-SpriteRenderer:
+--- !u!1001 &1050175183
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 889129927}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 1, g: 0.7311321, b: 0.7311321, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!1 &1442849433
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1442849434}
-  - component: {fileID: 1442849435}
-  m_Layer: 0
-  m_Name: Wall (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1442849434
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 130803431}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.b
+      value: 0.9312727
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.r
+      value: 0.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+--- !u!4 &1050175184 stripped
 Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 1050175183}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1442849433}
-  m_LocalRotation: {x: 0, y: 0, z: 0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -3, y: 0, z: 0}
-  m_LocalScale: {x: 11, y: 6, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1843739291}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 90}
---- !u!212 &1442849435
-SpriteRenderer:
+--- !u!1001 &1357014367
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1713400671}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall (2)
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.7071068
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 90
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.b
+      value: 0.9312727
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945997, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Color.r
+      value: 0.25
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+--- !u!4 &1357014368 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+  m_PrefabInstance: {fileID: 1357014367}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1442849433}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  m_Sprite: {fileID: 7482667652216324306, guid: 48e93eef0688c4a259cb0eddcd8661f7, type: 3}
-  m_Color: {r: 0.16509432, g: 1, b: 0.65306807, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
 --- !u!1 &1681359497
 GameObject:
   m_ObjectHideFlags: 0
@@ -609,6 +496,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1712980417}
   - component: {fileID: 1712980416}
+  - component: {fileID: 1712980419}
   m_Layer: 0
   m_Name: Player
   m_TagString: Untagged
@@ -681,6 +569,50 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1712980419
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1712980415}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 696a367ac05fc8948802390272aab9a2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &1713400670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1713400671}
+  m_Layer: 0
+  m_Name: LeftRightWall
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1713400671
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1713400670}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1010405425}
+  - {fileID: 1357014368}
+  m_Father: {fileID: 763872998}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1774561608
 GameObject:
   m_ObjectHideFlags: 0
@@ -697,7 +629,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1774561609
 Transform:
   m_ObjectHideFlags: 0
@@ -763,35 +695,60 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1843739290
-GameObject:
+--- !u!1001 &2912719508535047108
+PrefabInstance:
   m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1843739291}
-  m_Layer: 0
-  m_Name: LeftRightWall
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1843739291
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1843739290}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 861258844}
-  - {fileID: 1442849434}
-  m_Father: {fileID: 763872998}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 130803431}
+    m_Modifications:
+    - target: {fileID: 2912719507659945987, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_Name
+      value: Wall
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2912719507659945996, guid: c88c86f5d35c31947b144853ada54537, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c88c86f5d35c31947b144853ada54537, type: 3}

--- a/Assets/Scripts/CloseWallTimer.cs
+++ b/Assets/Scripts/CloseWallTimer.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class CloseWallTimer : MonoBehaviour
+{
+    //private int time = 3;
+    //[SerializeField] Text a;
+}

--- a/Assets/Scripts/CloseWallTimer.cs
+++ b/Assets/Scripts/CloseWallTimer.cs
@@ -1,9 +1,31 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.UI;
 
 public class CloseWallTimer : MonoBehaviour
 {
-    //private int time = 3;
-    //[SerializeField] Text a;
+    public Text closeWallTimerText;
+    public Text displayGoText;
+    public float countStartTime;
+    int seconds;
+
+    private void FixedUpdate()
+    {
+        countStartTime -= Time.deltaTime;
+
+        //floatŒ^‚©‚çintŒ^‚É•ÏŠ·
+        seconds = (int)countStartTime;
+
+        if (seconds > 0)
+        {
+            closeWallTimerText.text = seconds.ToString();
+        }
+        else if(seconds <= 0)
+        {
+            closeWallTimerText.text = "";
+        }
+       
+    }
+
 }

--- a/Assets/Scripts/CloseWallTimer.cs
+++ b/Assets/Scripts/CloseWallTimer.cs
@@ -3,27 +3,30 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
 
+/// <summary>
+/// Wallが動き始めるまでのwait時間をカウントするメソッド
+/// </summary>
 public class CloseWallTimer : MonoBehaviour
 {
-    public Text closeWallTimerText;
-    public Text displayGoText;
-    public float countStartTime;
-    int seconds;
+    [SerializeField] Text wallCloseTimerText;
+    [SerializeField] Text displayGoText; //変数困る
+    [SerializeField] float countStartTime;
+    int waitingSeconds;
 
     private void FixedUpdate()
     {
         countStartTime -= Time.deltaTime;
 
         //float型からint型に変換
-        seconds = (int)countStartTime;
+        waitingSeconds = (int)countStartTime;
 
-        if (seconds > 0)
+        if (waitingSeconds > 0)
         {
-            closeWallTimerText.text = seconds.ToString();
+            wallCloseTimerText.text = waitingSeconds.ToString();
         }
-        else if(seconds <= 0)
+        else if(waitingSeconds <= 0)
         {
-            closeWallTimerText.text = "";
+            wallCloseTimerText.text = "";
         }
        
     }

--- a/Assets/Scripts/CloseWallTimer.cs.meta
+++ b/Assets/Scripts/CloseWallTimer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7ec72fef5a5dd8b4eb71de4d03cdeef7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WallAnimation.cs
+++ b/Assets/Scripts/WallAnimation.cs
@@ -3,34 +3,37 @@ using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
 
+/// <summary>
+/// Wallのアニメーションの役割を司るメソッド
+/// </summary>
 public class WallAnimation : MonoBehaviour
 {
 
-    [SerializeField] float MoveTime;
+    [SerializeField] float wallMoveTime;
     
 
-    public void widthWallMove()
+    public void WallMove()
     {
         Transform myTransform = this.transform;
-        Vector2 pos = transform.position;
+        Vector3 pos = transform.position;
         
-
+        
         if (pos.x < 0)
         {
-            transform.DOLocalMove(new Vector2(-3, 0), MoveTime);
+            transform.DOLocalMove(new Vector3(-3f, 0, 0), wallMoveTime).SetDelay(3f);
         }
         
         else if(pos.x > 0)
         {
-            transform.DOLocalMove(new Vector2(3, 0), MoveTime);
+            transform.DOLocalMove(new Vector3(3f, 0, 0), wallMoveTime).SetDelay(3f);
         }
         else if (pos.y < 0)
         {
-            transform.DOLocalMove(new Vector2(0, -3), MoveTime);
+            transform.DOLocalMove(new Vector3(0, -3f, 0), wallMoveTime).SetDelay(3f);
         }
         else
         {
-            transform.DOLocalMove(new Vector2(0, 3), MoveTime);
+            transform.DOLocalMove(new Vector3(0, 3f, 0), wallMoveTime).SetDelay(3f);
         }
     }
 

--- a/Assets/Scripts/WallAnimation.cs
+++ b/Assets/Scripts/WallAnimation.cs
@@ -9,31 +9,34 @@ using DG.Tweening;
 public class WallAnimation : MonoBehaviour
 {
 
-    [SerializeField] float wallMoveTime;
+    [SerializeField] float moveWallSeconds;
     
 
-    public void WallMove()
+    public void MoveWall()
     {
-        Transform myTransform = this.transform;
+        Transform transform = this.transform;
         Vector3 pos = transform.position;
-        
+
+        float distanceCenter = 3.0f; ///壁のスタートするxまたはy座標から中央までの絶対値の距離
+        float closeWallWSeconds = 3.0f; ///壁が動き始めるまでの時間
+
         
         if (pos.x < 0)
         {
-            transform.DOLocalMove(new Vector3(-3f, 0, 0), wallMoveTime).SetDelay(3f);
+            transform.DOLocalMove(new Vector3(-distanceCenter, 0, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
         
         else if(pos.x > 0)
         {
-            transform.DOLocalMove(new Vector3(3f, 0, 0), wallMoveTime).SetDelay(3f);
+            transform.DOLocalMove(new Vector3(distanceCenter, 0, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
         else if (pos.y < 0)
         {
-            transform.DOLocalMove(new Vector3(0, -3f, 0), wallMoveTime).SetDelay(3f);
+            transform.DOLocalMove(new Vector3(0, -distanceCenter, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
         else
         {
-            transform.DOLocalMove(new Vector3(0, 3f, 0), wallMoveTime).SetDelay(3f);
+            transform.DOLocalMove(new Vector3(0, distanceCenter, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
     }
 

--- a/Assets/Scripts/WallAnimation.cs
+++ b/Assets/Scripts/WallAnimation.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using DG.Tweening;
+
+public class WallAnimation : MonoBehaviour
+{
+
+    [SerializeField] float MoveTime;
+    
+
+    public void widthWallMove()
+    {
+        Transform myTransform = this.transform;
+        Vector2 pos = transform.position;
+        
+
+        if (pos.x < 0)
+        {
+            transform.DOLocalMove(new Vector2(-3, 0), MoveTime);
+        }
+        
+        else if(pos.x > 0)
+        {
+            transform.DOLocalMove(new Vector2(3, 0), MoveTime);
+        }
+        else if (pos.y < 0)
+        {
+            transform.DOLocalMove(new Vector2(0, -3), MoveTime);
+        }
+        else
+        {
+            transform.DOLocalMove(new Vector2(0, 3), MoveTime);
+        }
+    }
+
+}

--- a/Assets/Scripts/WallAnimation.cs
+++ b/Assets/Scripts/WallAnimation.cs
@@ -11,11 +11,10 @@ public class WallAnimation : MonoBehaviour
 
     [SerializeField] float moveWallSeconds;
     
-
     public void MoveWall()
     {
-        Transform transform = this.transform;
         Vector3 pos = transform.position;
+
 
         float distanceCenter = 3.0f; ///壁のスタートするxまたはy座標から中央までの絶対値の距離
         float closeWallWSeconds = 3.0f; ///壁が動き始めるまでの時間
@@ -25,7 +24,6 @@ public class WallAnimation : MonoBehaviour
         {
             transform.DOLocalMove(new Vector3(-distanceCenter, 0, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
-        
         else if(pos.x > 0)
         {
             transform.DOLocalMove(new Vector3(distanceCenter, 0, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
@@ -39,5 +37,7 @@ public class WallAnimation : MonoBehaviour
             transform.DOLocalMove(new Vector3(0, distanceCenter, 0), moveWallSeconds).SetDelay(closeWallWSeconds);
         }
     }
+
+
 
 }

--- a/Assets/Scripts/WallAnimation.cs.meta
+++ b/Assets/Scripts/WallAnimation.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 386ec9c8df386644b910d86f957b9c2e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/WallManager.cs
+++ b/Assets/Scripts/WallManager.cs
@@ -15,7 +15,7 @@ public class WallManager : MonoBehaviour
     }
 
     private void FixedUpdate()
-    {   
+    {
         
     }
 

--- a/Assets/Scripts/WallManager.cs
+++ b/Assets/Scripts/WallManager.cs
@@ -3,18 +3,17 @@ using System.Collections.Generic;
 using UnityEngine;
 using DG.Tweening;
 
+/// <summary>
+/// Wallの全ての処理を管理するメソッド
+/// </summary>
 public class WallManager : MonoBehaviour
 {
     [SerializeField] WallAnimation wallAnimation;
 
-    void Stare()
-    {
-        
-    }
 
-    void FixedUpdate()
+    private void FixedUpdate()
     {
-        wallAnimation.widthWallMove();
+        wallAnimation.WallMove();
     }
 
 }

--- a/Assets/Scripts/WallManager.cs
+++ b/Assets/Scripts/WallManager.cs
@@ -9,11 +9,15 @@ using DG.Tweening;
 public class WallManager : MonoBehaviour
 {
     [SerializeField] WallAnimation wallAnimation;
-
+    private void Start()
+    {
+        wallAnimation.MoveWall();
+    }
 
     private void FixedUpdate()
     {
-        wallAnimation.WallMove();
+        
+        
     }
 
 }

--- a/Assets/Scripts/WallManager.cs
+++ b/Assets/Scripts/WallManager.cs
@@ -15,8 +15,7 @@ public class WallManager : MonoBehaviour
     }
 
     private void FixedUpdate()
-    {
-        
+    {   
         
     }
 

--- a/Assets/Scripts/WallManager.cs
+++ b/Assets/Scripts/WallManager.cs
@@ -1,17 +1,20 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using DG.Tweening;
 
 public class WallManager : MonoBehaviour
 {
-    void Start()
+    [SerializeField] WallAnimation wallAnimation;
+
+    void Stare()
     {
         
     }
 
-    // Update is called once per frame
-    void Update()
+    void FixedUpdate()
     {
-        
+        wallAnimation.widthWallMove();
     }
+
 }

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -3,7 +3,8 @@
 --- !u!78 &1
 TagManager:
   serializedVersion: 2
-  tags: []
+  tags:
+  - Wall
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
縦に動く上下の壁、横に動く左右の壁がインスペクターのMoveTimeに代入した時間に合わせて閉じるDoTweenのアニメーションを作成。
再生すると容量が重たいのか滑らかに動かないバグが発生。